### PR TITLE
fix: aclarar que asalariado incluye pensionistas en el asistente

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "larenta",
       "version": "1.0.0",
+      "license": "MIT",
       "dependencies": {
         "@astrojs/react": "^5.0.1",
         "@astrojs/sitemap": "^3.7.1",

--- a/src/components/Report.tsx
+++ b/src/components/Report.tsx
@@ -1,9 +1,10 @@
 import { useState, useMemo, useRef } from "react";
-import type { DeduccionIndex } from "../lib/types";
+import type { DeduccionIndex, SituacionLaboral } from "../lib/types";
 import {
   CCAA_MAP,
   CATEGORIA_LABELS,
   CATEGORIA_COLORS,
+  LABORAL_LABELS,
   cleanName,
   fichaUrl,
   relevanciaText,
@@ -22,7 +23,7 @@ function pushEvent(event: string, params?: Record<string, unknown>) {
 interface ReportProps {
   deducciones: DeduccionIndex[];
   ccaa: string;
-  laboral: string;
+  laboral: SituacionLaboral;
   situaciones: string[];
   datosEconomicos?: Record<string, string>;
   onBack: () => void;
@@ -169,6 +170,8 @@ export default function Report({ deducciones, ccaa, laboral, situaciones, datosE
     };
   }, [filteredDeducciones, datosEconomicos]);
 
+  const laboralLabel = LABORAL_LABELS[laboral];
+
   function toggleCategory(cat: string) {
     setExpandedCats((prev) => {
       const next = new Set(prev);
@@ -253,7 +256,7 @@ export default function Report({ deducciones, ccaa, laboral, situaciones, datosE
 
       doc.setFontSize(11);
       doc.setTextColor(66, 71, 82);
-      doc.text(`${CCAA_MAP[ccaa] || "Todas"} · ${laboral === "ambos" ? "Asalariado + Autónomo" : laboral === "asalariado" ? "Asalariado" : "Autónomo"}${userIncome ? ` · ${userIncome.toLocaleString("es-ES")} € brutos` : ""}`, margin, y);
+      doc.text(`${CCAA_MAP[ccaa] || "Todas"} · ${laboralLabel}${userIncome ? ` · ${userIncome.toLocaleString("es-ES")} € brutos` : ""}`, margin, y);
       y += 10;
 
       // Estimated savings
@@ -338,9 +341,6 @@ export default function Report({ deducciones, ccaa, laboral, situaciones, datosE
       setGeneratingPdf(false);
     }
   }
-
-  const laboralLabel = laboral === "ambos" ? "Asalariado + Autónomo"
-    : laboral === "asalariado" ? "Asalariado" : "Autónomo";
 
   return (
     <div className="animate-fade-up" ref={reportRef}>

--- a/src/components/Wizard.tsx
+++ b/src/components/Wizard.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useEffect } from "react";
-import type { DeduccionIndex } from "../lib/types";
+import type { DeduccionIndex, SituacionLaboral } from "../lib/types";
 import {
   CCAA_MAP,
   CIUDADES_AUTONOMAS,
@@ -22,7 +22,7 @@ interface WizardProps {
 
 interface Answers {
   ccaa: string;
-  laboral: "asalariado" | "autonomo" | "ambos" | "";
+  laboral: SituacionLaboral | "";
   situaciones: string[];
   edad: string;
   alquiler: "si" | "no" | "";
@@ -71,7 +71,7 @@ const CCAA_OPTIONS = Object.entries(CCAA_MAP)
   .sort(([, a], [, b]) => a.localeCompare(b));
 
 const LABORAL_OPTIONS = [
-  { value: "asalariado", label: "Asalariado/a",  desc: "Trabajo por cuenta ajena",  icon: "💼" },
+  { value: "asalariado", label: "Asalariado/a o pensionista", desc: "Trabajo por cuenta ajena o cobro una pensión", icon: "💼" },
   { value: "autonomo",   label: "Autónomo/a",    desc: "Trabajo por cuenta propia",  icon: "🧾" },
   { value: "ambos",      label: "Ambos",         desc: "Combino empleo y actividad", icon: "⚖️" },
 ] as const;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -60,6 +60,8 @@ export interface Stats {
   ccaa_lista: { codigo: string; nombre: string; total: number }[];
 }
 
+export type SituacionLaboral = "asalariado" | "autonomo" | "ambos";
+
 export const CCAA_MAP: Record<string, string> = {
   AND: "Andalucía",
   ARA: "Aragón",
@@ -82,6 +84,12 @@ export const CCAA_MAP: Record<string, string> = {
 
 /** Códigos de ciudades autónomas sin deducciones autonómicas propias */
 export const CIUDADES_AUTONOMAS = ["CML"] as const;
+
+export const LABORAL_LABELS: Record<SituacionLaboral, string> = {
+  asalariado: "Asalariado/a o pensionista",
+  autonomo: "Autónomo",
+  ambos: "Asalariado + Autónomo",
+};
 
 export const CATEGORIA_LABELS: Record<string, string> = {
   familia: "👨‍👩‍👧 Familia",


### PR DESCRIPTION
## Descripción

Este PR ajusta el wizard del asistente de `/asistente` para dejar claro que la opción de asalariado también cubre a personas pensionistas, sin añadir una categoría nueva ni modificar la lógica fiscal existente.

Cambios principales:
- Se actualiza el copy de la opción laboral a `Asalariado/a o pensionista`.
- Se actualiza la descripción de esa opción a `Trabajo por cuenta ajena o cobro una pensión`.
- Se unifica la etiqueta usada en el informe para reflejar ese mismo texto.

No se modifican fichas JSON, índices ni reglas de filtrado de deducciones.

## Tipo de cambio

- [ ] Corrección de datos (ficha JSON)
- [x] Corrección de bug
- [ ] Nueva funcionalidad
- [ ] Documentación
- [x] Otro: ajuste de copy y simplificación de UX en el wizard

## Checklist

- [x] He ejecutado `npm run build` sin errores
- [ ] He ejecutado `node scripts/test_income_filter.mjs` (si aplica)
- [ ] He regenerado los índices con `python3 scripts/generate_indexes.py` (si he modificado fichas)
