### PR TITLE
fix: sync hardcoded counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Tu guía completa del IRPF 2025. Todas las deducciones estatales y autonómicas 
 
 Cada año, millones de personas hacen la declaración de la renta sin saber que podrían deducirse cientos de euros. La información existe, pero está repartida entre el BOE, la web de la AEAT y 15 normativas autonómicas diferentes.
 
-**larenta.es** reúne las **375 deducciones del IRPF 2025** en un solo sitio y ofrece tres herramientas:
+**larenta.es** reúne las **377 deducciones del IRPF 2025** en un solo sitio y ofrece tres herramientas:
 
 - **[Asistente interactivo](https://www.larenta.es/asistente)** — responde unas preguntas y obtén tus deducciones aplicables en menos de 2 minutos.
 - **[Explorador de deducciones](https://www.larenta.es/explorador)** — busca y filtra entre todas las deducciones por CCAA, categoría, relevancia o texto.
@@ -74,7 +74,7 @@ Sin esta variable, todo funciona excepto el endpoint `/api/send-report`.
 ```
 larenta/
 ├── data/                    # Datos del IRPF (JSON)
-│   ├── deducciones.json     # 375 deducciones completas (con contenido markdown)
+│   ├── deducciones.json     # 377 deducciones completas (con contenido markdown)
 │   ├── wizard_index.json    # Índice ligero para el asistente
 │   ├── explorer_index.json  # Índice ligero para el explorador
 │   ├── guias.json           # Guías temáticas del IRPF
@@ -110,9 +110,9 @@ larenta/
 
 ## Datos
 
-El proyecto contiene **375 deducciones** extraídas del Manual Práctico de Renta 2025 de la AEAT, organizadas en:
+El proyecto contiene **377 deducciones** extraídas del Manual Práctico de Renta 2025 de la AEAT, organizadas en:
 
-- **16 comunidades autónomas** + deducciones estatales
+- **15 comunidades autónomas con deducciones propias** + deducciones estatales
 - **9 categorías**: vivienda, familia, educación, donativos, empresa, energía, movilidad, salud, otros
 - **3 niveles de relevancia**: alta (•••), media (••), baja (•)
 
@@ -132,7 +132,7 @@ Para regenerar los índices tras modificar los datos:
 python3 scripts/generate_indexes.py
 ```
 
-Los archivos fuente de datos están fuera de `larenta/`, en el directorio padre `data/fichas/` (375 ficheros JSON individuales). El script `generate_indexes.py` los agrega en los JSON optimizados que usa la webapp.
+Los archivos fuente de datos están fuera de `larenta/`, en el directorio padre `data/fichas/` (377 ficheros JSON individuales). El script `generate_indexes.py` los agrega en los JSON optimizados que usa la webapp.
 
 ## Cómo contribuir
 

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,4 +1,6 @@
 ---
+import { getStats } from "../lib/data";
+
 interface Props {
   title: string;
   description?: string;
@@ -6,9 +8,11 @@ interface Props {
   canonical?: string;
 }
 
+const stats = getStats();
+
 const {
   title,
-  description = "Descubre todas las deducciones del IRPF 2025 en segundos. Asistente interactivo + explorador con las 377 deducciones estatales y autonómicas.",
+  description = `Descubre todas las deducciones del IRPF 2025 en segundos. Asistente interactivo + explorador con las ${stats.total_deducciones} deducciones estatales y autonómicas.`,
   ogImage = "/api/og?title=Tu+gu%C3%ADa+completa+del+IRPF",
   canonical,
 } = Astro.props;

--- a/src/pages/explorador.astro
+++ b/src/pages/explorador.astro
@@ -8,7 +8,7 @@ const deducciones = getExplorerIndex();
 
 <Base
   title="Explorador de deducciones"
-  description="Busca y filtra entre las 377 deducciones del IRPF 2025 por comunidad autónoma, categoría, relevancia y más."
+  description={`Busca y filtra entre las ${deducciones.length} deducciones del IRPF 2025 por comunidad autónoma, categoría, relevancia y más.`}
   ogImage="/api/og?title=Explorador+de+deducciones&subtitle=Busca+y+filtra+377+deducciones+del+IRPF&badge=377+deducciones"
 >
   <section class="max-w-4xl mx-auto px-4 sm:px-6 py-8 sm:py-12">

--- a/src/pages/guia/index.astro
+++ b/src/pages/guia/index.astro
@@ -1,6 +1,9 @@
 ---
 import Base from "../../layouts/Base.astro";
+import { getStats } from "../../lib/data";
 import guias from "../../../data/guias.json";
+
+const stats = getStats();
 ---
 
 <Base
@@ -59,15 +62,15 @@ import guias from "../../../data/guias.json";
           class=\"grid grid-cols-2 gap-4\"
         >
           <div class="card" style="padding: 1.5rem; text-align: center;">
-            <div style="font-size: 2rem; font-weight: 800; color: var(--color-primary);">8</div>
+            <div style="font-size: 2rem; font-weight: 800; color: var(--color-primary);">{guias.length}</div>
             <div style="font-size: 0.8rem; color: var(--color-on-surface-variant); margin-top: 0.25rem;">guías temáticas</div>
           </div>
           <div class="card" style="padding: 1.5rem; text-align: center;">
-            <div style="font-size: 2rem; font-weight: 800; color: var(--color-primary);">377</div>
+            <div style="font-size: 2rem; font-weight: 800; color: var(--color-primary);">{stats.total_deducciones}</div>
             <div style="font-size: 0.8rem; color: var(--color-on-surface-variant); margin-top: 0.25rem;">deducciones catalogadas</div>
           </div>
           <div class="card" style="padding: 1.5rem; text-align: center;">
-            <div style="font-size: 2rem; font-weight: 800; color: var(--color-primary);">19</div>
+            <div style="font-size: 2rem; font-weight: 800; color: var(--color-primary);">{stats.total_ccaa}</div>
             <div style="font-size: 0.8rem; color: var(--color-on-surface-variant); margin-top: 0.25rem;">comunidades autónomas</div>
           </div>
           <div class="card" style="padding: 1.5rem; text-align: center;">


### PR DESCRIPTION
## Descripción

Sincroniza contadores hardcodeados que habían quedado desactualizados con los datos reales del proyecto.

Cambios incluidos:
- Actualiza la documentación de `README.md` de 375 a 377 deducciones y corrige el texto sobre CCAA con deducciones propias.
- Hace dinámico el `description` por defecto en `Base.astro` usando `stats.total_deducciones`.
- Hace dinámico el texto descriptivo del explorador usando `deducciones.length`.
- Hace dinámicas las estadísticas de la portada de la guía usando `guias.length` y `stats`.

## Tipo de cambio

- [ ] Corrección de datos (ficha JSON)
- [x] Corrección de bug
- [ ] Nueva funcionalidad
- [x] Documentación
- [ ] Otro: ___

## Checklist

- [x] He ejecutado `npm run build` sin errores
- [ ] He ejecutado `node scripts/test_income_filter.mjs` (si aplica)
- [ ] He regenerado los índices con `python3 scripts/generate_indexes.py` (si he modificado fichas)

Notas:
- No he modificado fichas JSON ni índices.
- El cambio no afecta al filtrado del asistente.
- En este checkout no existe `scripts/test_income_filter.mjs`, aunque sí aparece mencionado en `CONTRIBUTING.md` y en la plantilla de PR.
